### PR TITLE
fix: split dir flags for schemas and crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,22 @@ If you are working offline or do not have access to a cluster with the CRDs inst
 you may supply a directory to use as a search path for types:
 
 ```sh
-kubectl validate ./my_crd.yaml --local-schemas ./path/to/folder/with/crds
+kubectl validate ./my_crd.yaml --local-crds ./path/to/folder/with/crds
+```
+
+### Local openapi schemas
+
+If you are working offline or do not have access to a cluster to load openapi schemas,
+you may supply a directory to use as a search path for schemas:
+
+```sh
+kubectl validate ./my_crd.yaml --local-schemas ./path/to/folder/with/schemas
+```
+
+Directory should have openapi files following directory layout:
+```sh
+/<apis>/<group>/<version>.json
+/api/<version>.json
 ```
 
 ## JSON Output

--- a/pkg/cmd/validate_test.go
+++ b/pkg/cmd/validate_test.go
@@ -70,7 +70,7 @@ func TestValidationErrorsIndividually(t *testing.T) {
 			rootCmd.SetArgs([]string{path})
 
 			require.NoError(t, rootCmd.Flags().Set("version", "1.27"))
-			require.NoError(t, rootCmd.Flags().Set("local-schemas", crdsDir))
+			require.NoError(t, rootCmd.Flags().Set("local-crds", crdsDir))
 			require.NoError(t, rootCmd.Flags().Set("schema-patches", patchesDir))
 			require.NoError(t, rootCmd.Flags().Set("output", "json"))
 


### PR DESCRIPTION
This PR splits dir flags for schemas and crds.