### PR TITLE
refactor: introduce groupversion package

### DIFF
--- a/pkg/openapiclient/composite.go
+++ b/pkg/openapiclient/composite.go
@@ -1,56 +1,12 @@
 package openapiclient
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"k8s.io/client-go/openapi"
-	"k8s.io/kube-openapi/pkg/spec3"
-	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/kubectl-validate/pkg/openapiclient/groupversion"
 )
 
 type compositeClient struct {
 	clients []openapi.Client
-}
-
-type compositeGroupVersion struct {
-	gvFetchers []openapi.GroupVersion
-}
-
-func (g compositeGroupVersion) Schema(contentType string) ([]byte, error) {
-	if len(g.gvFetchers) == 0 {
-		return nil, fmt.Errorf("no fetches for groupversion")
-	} else if len(g.gvFetchers) == 1 {
-		return g.gvFetchers[0].Schema(contentType)
-	}
-
-	combined := spec3.OpenAPI{
-		Components: &spec3.Components{
-			Schemas: map[string]*spec.Schema{},
-		},
-	}
-
-	for _, fetcher := range g.gvFetchers {
-		fetched, err := fetcher.Schema(contentType)
-		if err != nil {
-			return nil, err
-		}
-
-		var parsed spec3.OpenAPI
-		if err := json.Unmarshal(fetched, &parsed); err != nil {
-			return nil, err
-		} else if parsed.Components == nil {
-			continue
-		}
-
-		for k, d := range parsed.Components.Schemas {
-			if _, existing := combined.Components.Schemas[k]; !existing {
-				combined.Components.Schemas[k] = d
-			}
-		}
-	}
-
-	return json.Marshal(&combined)
 }
 
 // client which tries multiple clients in a priority order for an openapi spec
@@ -59,20 +15,19 @@ func NewComposite(clients ...openapi.Client) openapi.Client {
 }
 
 func (c compositeClient) Paths() (map[string]openapi.GroupVersion, error) {
-	merged := map[string]openapi.GroupVersion{}
+	merged := map[string][]openapi.GroupVersion{}
 	for _, client := range c.clients {
-		singleMap, err := client.Paths()
+		paths, err := client.Paths()
 		if err != nil {
 			continue
 		}
-
-		for k, v := range singleMap {
-			if existing, exists := merged[k]; exists {
-				existing.(*compositeGroupVersion).gvFetchers = append(existing.(*compositeGroupVersion).gvFetchers, v)
-			} else {
-				merged[k] = &compositeGroupVersion{gvFetchers: []openapi.GroupVersion{v}}
-			}
+		for k, v := range paths {
+			merged[k] = append(merged[k], v)
 		}
 	}
-	return merged, nil
+	composite := map[string]openapi.GroupVersion{}
+	for k, v := range merged {
+		composite[k] = groupversion.NewForComposite(v...)
+	}
+	return composite, nil
 }

--- a/pkg/openapiclient/groupversion/composite.go
+++ b/pkg/openapiclient/groupversion/composite.go
@@ -1,0 +1,54 @@
+package groupversion
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/client-go/openapi"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+type compositeGroupVersion struct {
+	gvFetchers []openapi.GroupVersion
+}
+
+func (gv *compositeGroupVersion) Schema(contentType string) ([]byte, error) {
+	if len(gv.gvFetchers) == 0 {
+		return nil, fmt.Errorf("no fetches for groupversion")
+	} else if len(gv.gvFetchers) == 1 {
+		return gv.gvFetchers[0].Schema(contentType)
+	}
+
+	combined := spec3.OpenAPI{
+		Components: &spec3.Components{
+			Schemas: map[string]*spec.Schema{},
+		},
+	}
+
+	for _, fetcher := range gv.gvFetchers {
+		fetched, err := fetcher.Schema(contentType)
+		if err != nil {
+			return nil, err
+		}
+
+		var parsed spec3.OpenAPI
+		if err := json.Unmarshal(fetched, &parsed); err != nil {
+			return nil, err
+		} else if parsed.Components == nil {
+			continue
+		}
+
+		for k, d := range parsed.Components.Schemas {
+			if _, existing := combined.Components.Schemas[k]; !existing {
+				combined.Components.Schemas[k] = d
+			}
+		}
+	}
+
+	return json.Marshal(&combined)
+}
+
+func NewForComposite(gvFetchers ...openapi.GroupVersion) openapi.GroupVersion {
+	return &compositeGroupVersion{gvFetchers}
+}

--- a/pkg/openapiclient/groupversion/file.go
+++ b/pkg/openapiclient/groupversion/file.go
@@ -1,0 +1,27 @@
+package groupversion
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/openapi"
+	"sigs.k8s.io/kubectl-validate/pkg/utils"
+)
+
+type fileGroupVersion struct {
+	fs       fs.FS
+	filepath string
+}
+
+func (gv *fileGroupVersion) Schema(contentType string) ([]byte, error) {
+	if strings.ToLower(contentType) != runtime.ContentTypeJSON {
+		return nil, fmt.Errorf("only application/json content type is supported")
+	}
+	return utils.ReadFile(gv.fs, gv.filepath)
+}
+
+func NewForFile(fs fs.FS, filepath string) openapi.GroupVersion {
+	return &fileGroupVersion{fs, filepath}
+}

--- a/pkg/openapiclient/groupversion/http.go
+++ b/pkg/openapiclient/groupversion/http.go
@@ -1,0 +1,34 @@
+package groupversion
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"k8s.io/client-go/openapi"
+)
+
+type httpGroupVersion struct {
+	uri string
+}
+
+func (gv *httpGroupVersion) Schema(contentType string) ([]byte, error) {
+	//TODO: responses use and respect ETAG. use a disk cache
+	req, err := http.NewRequest("GET", gv.uri, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Accept", contentType)
+	// Make HTTP request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+func NewForHttp(uri string) openapi.GroupVersion {
+	return &httpGroupVersion{uri}
+}

--- a/pkg/openapiclient/groupversion/openapi.go
+++ b/pkg/openapiclient/groupversion/openapi.go
@@ -1,0 +1,26 @@
+package groupversion
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/openapi"
+	"k8s.io/kube-openapi/pkg/spec3"
+)
+
+type OpenApiGroupVersion struct {
+	*spec3.OpenAPI
+}
+
+func (gv *OpenApiGroupVersion) Schema(contentType string) ([]byte, error) {
+	if strings.ToLower(contentType) != runtime.ContentTypeJSON {
+		return nil, fmt.Errorf("only application/json content type is supported")
+	}
+	return json.Marshal(gv.OpenAPI)
+}
+
+func NewForOpenAPI(spec *spec3.OpenAPI) openapi.GroupVersion {
+	return &OpenApiGroupVersion{spec}
+}

--- a/pkg/openapiclient/groupversion/overlay.go
+++ b/pkg/openapiclient/groupversion/overlay.go
@@ -1,0 +1,43 @@
+package groupversion
+
+import (
+	"errors"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/openapi"
+)
+
+type PatchLoaderFn = func(string) []byte
+
+type overlayGroupVersion struct {
+	delegate    openapi.GroupVersion
+	patchLoader PatchLoaderFn
+	path        string
+}
+
+func (gv *overlayGroupVersion) Schema(contentType string) ([]byte, error) {
+	patch := gv.patchLoader(gv.path)
+	if patch == nil {
+		return gv.delegate.Schema(contentType)
+	}
+
+	if contentType != runtime.ContentTypeJSON {
+		return nil, errors.New("unsupported content type")
+	}
+	delegateRes, err := gv.delegate.Schema(contentType)
+	if err != nil {
+		return nil, err
+	}
+
+	patchedJS, err := jsonpatch.MergePatch(delegateRes, patch)
+	if err == jsonpatch.ErrBadJSONPatch {
+		return nil, k8serrors.NewBadRequest(err.Error())
+	}
+	return patchedJS, err
+}
+
+func NewForOverlay(delegate openapi.GroupVersion, patchLoader PatchLoaderFn, path string) openapi.GroupVersion {
+	return &overlayGroupVersion{delegate, patchLoader, path}
+}

--- a/pkg/openapiclient/hardcoded_builtins.go
+++ b/pkg/openapiclient/hardcoded_builtins.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"k8s.io/client-go/openapi"
+	"sigs.k8s.io/kubectl-validate/pkg/openapiclient/groupversion"
 )
 
 //go:embed builtins
@@ -41,7 +42,7 @@ func (k hardcodedResolver) Paths() (map[string]openapi.GroupVersion, error) {
 				// chop extension
 				ext := filepath.Ext(v.Name())
 				version := strings.TrimSuffix(v.Name(), ext)
-				res[fmt.Sprintf("api/%s", version)] = localGroupVersion{fs: &hardcodedBuiltins, filepath: filepath.Join(apiDir, v.Name())}
+				res[fmt.Sprintf("api/%s", version)] = groupversion.NewForFile(&hardcodedBuiltins, filepath.Join(apiDir, v.Name()))
 			}
 
 			apisDir := filepath.Join("builtins", v.Name(), "apis")
@@ -57,7 +58,7 @@ func (k hardcodedResolver) Paths() (map[string]openapi.GroupVersion, error) {
 					// chop extension
 					ext := filepath.Ext(v.Name())
 					version := strings.TrimSuffix(v.Name(), ext)
-					res[fmt.Sprintf("apis/%s/%s", g.Name(), version)] = localGroupVersion{fs: &hardcodedBuiltins, filepath: filepath.Join(gDir, v.Name())}
+					res[fmt.Sprintf("apis/%s/%s", g.Name(), version)] = groupversion.NewForFile(&hardcodedBuiltins, filepath.Join(gDir, v.Name()))
 				}
 			}
 

--- a/pkg/openapiclient/local_crds_test.go
+++ b/pkg/openapiclient/local_crds_test.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/openapi"
+	"sigs.k8s.io/kubectl-validate/pkg/openapiclient/groupversion"
 )
 
 func TestNewLocalCRDFiles(t *testing.T) {
@@ -127,7 +128,7 @@ func Test_localCRDsClient_Paths(t *testing.T) {
 				got = map[string]sets.Set[string]{}
 				for key, value := range paths {
 					got[key] = sets.New[string]()
-					for component := range value.(inmemoryGroupVersion).Components.Schemas {
+					for component := range value.(*groupversion.OpenApiGroupVersion).Components.Schemas {
 						got[key] = got[key].Insert(component)
 					}
 				}


### PR DESCRIPTION
This PR introduces a `groupversion` package to store our `GroupVersion` implementations.

This will make them more reusable and isolated at the same time.