### PR TITLE
fix: remove refs issue

### DIFF
--- a/pkg/validatorfactory/factory.go
+++ b/pkg/validatorfactory/factory.go
@@ -201,6 +201,7 @@ func removeRefs(defs map[string]*spec.Schema, sch spec.Schema) spec.Schema {
 		vCopy.Default = nil
 		vCopy.Example = nil
 		vCopy.Description = ""
+		vCopy.Extensions = nil
 
 		if reflect.DeepEqual(vCopy, spec.Schema{}) {
 			return removeRefs(defs, sch.AllOf[0])

--- a/testcases/manifests/deployment_with_strategy.yaml
+++ b/testcases/manifests/deployment_with_strategy.yaml
@@ -1,0 +1,39 @@
+# {
+#     "status": "Success",
+#     "message": ""
+# }
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      service: my-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        service: my-service
+    spec:
+       containers:
+        - name: main
+          image: my-service:latest
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP


### PR DESCRIPTION
This PR fixes a `removeRefs` issue.

It looks like we need to reset extensions before comparing with an empty schema.

Fixes https://github.com/kubernetes-sigs/kubectl-validate/issues/54