### PR TITLE
Generate patches for native type schema deficiencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode
+/.tool-versions

--- a/cmd/download-builtin-schemas/main.go
+++ b/cmd/download-builtin-schemas/main.go
@@ -1,30 +1,48 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 	"sigs.k8s.io/kubectl-validate/pkg/openapiclient"
+	"sigs.k8s.io/kubectl-validate/pkg/utils"
 )
 
 // Downloads builtin schemas from GitHub and saves them to disk for embedding
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Printf("Usage: download-builtin-schemas outputDirectory")
+	if len(os.Args) != 2 && len(os.Args) != 3 {
+		fmt.Printf("Usage: download-builtin-schemas outputDirectory [patchesOutputDirectory]")
 		return
 	}
 
 	outputDir := os.Args[1]
-	err := os.Mkdir(outputDir, 0o755)
+	err := os.MkdirAll(outputDir, 0o755)
 	if err != nil {
 		panic(err)
+	}
+
+	patchesDir := ""
+	if len(os.Args) == 3 {
+		patchesDir = os.Args[2]
+
+		if err := os.MkdirAll(patchesDir, 0o755); err != nil {
+			panic(err)
+		}
 	}
 
 	// Versions 1.0-1.22 did not have OpenAPIV3 schemas.
 	for i := 23; ; i++ {
 		version := fmt.Sprintf("1.%d", i)
 		fetcher := openapiclient.NewGitHubBuiltins(version)
+		// fetcher := openapiclient.NewHardcodedBuiltins(version)
 		schemas, err := fetcher.Paths()
 		if err != nil {
 			break
@@ -36,6 +54,21 @@ func main() {
 				panic(err)
 			}
 
+			var gv schema.GroupVersion
+			if strings.HasPrefix(k, "apis/") {
+				gv, err = schema.ParseGroupVersion(k[5:])
+				if err != nil {
+					panic(err)
+				}
+			} else if strings.HasPrefix(k, "api/") {
+				gv, err = schema.ParseGroupVersion(k[4:])
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				panic(fmt.Errorf("unknown path %s", k))
+			}
+
 			path := filepath.Join(outputDir, version, k+".json")
 			dir, _ := filepath.Split(path)
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -45,10 +78,185 @@ func main() {
 			if err := os.WriteFile(path, data, 0o755); err != nil {
 				panic(err)
 			}
+
+			// Postprocess schema and save off the diff
+			if len(patchesDir) > 0 {
+				patchPath := filepath.Join(patchesDir, version, k+".json")
+				dir, _ := filepath.Split(patchPath)
+
+				parsed := &spec3.OpenAPI{}
+				if err := json.Unmarshal(data, parsed); err != nil {
+					panic(err)
+				}
+
+				for k, d := range parsed.Components.Schemas {
+					applySchemaPatches(i, gv, k, d)
+				}
+
+				newJSON, err := json.Marshal(parsed)
+				if err != nil {
+					panic(err)
+				}
+
+				patch, err := jsonpatch.CreateMergePatch(data, newJSON)
+				if err != nil {
+					panic(err)
+				}
+
+				if len(patch) > 2 {
+					buf := bytes.NewBuffer(nil)
+					if err := json.Indent(buf, patch, "", "    "); err != nil {
+						panic(err)
+					}
+
+					if err := os.MkdirAll(dir, 0o755); err != nil {
+						panic(err)
+					}
+
+					if err := os.WriteFile(patchPath, buf.Bytes(), 0o755); err != nil {
+						panic(err)
+					}
+				}
+			}
 		}
 	}
 
 	//TODO: Download OpenAPIV3 schemas and convert to V3?
 	// might be error prone since some (very few like IntOrString) types are
 	// handled differently
+}
+
+type SchemaPatch struct {
+	Slug        string
+	Description string
+
+	// (Inclusive) version range for which this patch applies
+	MinMinorVersion int
+	MaxMinorVersion int
+
+	// Nil is wildcard
+	AppliesToGV func(schema.GroupVersion) bool
+	Transformer utils.SchemaVisitor
+}
+
+var zero int64 = int64(0)
+var schemaPatches []SchemaPatch = []SchemaPatch{
+	{
+		Slug:            "AllowEmptyByteFormat",
+		Description:     "Work around discrepency between treatment of native vs CRD `byte` strings. Native types allow empty, CRDs do not",
+		MinMinorVersion: 0,
+		MaxMinorVersion: 0,
+		AppliesToGV:     nil,
+		Transformer: utils.PostorderVisitor(func(ctx utils.VisitingContext, s *spec.Schema) bool {
+			if s.Format != "byte" || len(s.Type) != 1 || s.Type[0] != "string" {
+				return true
+			}
+
+			// Change format to "", and add new `$and: {$or: [{format: "byte"}, {maxLength: 0}]}
+			s.AllOf = append(s.AllOf, spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					AnyOf: []spec.Schema{
+						{
+							SchemaProps: spec.SchemaProps{
+								Format: s.Format,
+							},
+						},
+						{
+							SchemaProps: spec.SchemaProps{
+								MaxLength: &zero,
+							},
+						},
+					},
+				},
+			})
+			s.Format = ""
+			return true
+		}),
+	},
+	{
+		Slug:        "AllowEmptyDateTime",
+		Description: "metav1.Time published OpenAPI definitions do not allow empty/null, but Kubernetes in practice does.",
+		Transformer: utils.PostorderVisitor(func(ctx utils.VisitingContext, s *spec.Schema) bool {
+			if s.Format != "date-time" || len(s.Type) != 1 || s.Type[0] != "string" {
+				return true
+			}
+
+			// Change format to "", and add new `$and: {$or: [{format: "date-time"}, {maxLength: 0}]}
+			s.AllOf = append(s.AllOf, spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					AnyOf: []spec.Schema{
+						{
+							SchemaProps: spec.SchemaProps{
+								Format: s.Format,
+							},
+						},
+						{
+							SchemaProps: spec.SchemaProps{
+								MaxLength: &zero,
+							},
+						},
+					},
+				},
+			})
+			s.Format = ""
+			return true
+		}),
+	},
+	{
+		Slug:        "RemoveInvalidObjectDefaults",
+		Description: "`default: {}` is supplied for many schemas which are not objects. This would cause errors for CRDs but not native types",
+		Transformer: utils.PostorderVisitor(func(ctx utils.VisitingContext, s *spec.Schema) bool {
+			if s.Default == nil {
+				return true
+			} else if len(s.Type) > 1 {
+				return true
+			} else if objDefault, ok := s.Default.(map[string]interface{}); !ok || len(objDefault) != 0 {
+				// Skip defaults that are not 0-length maps
+				return true
+			}
+
+			if len(s.Type) == 1 {
+				switch s.Type[0] {
+				case "object":
+					// do nothing
+				case "array":
+					// replace with array-typed zero value
+					s.Default = []interface{}{}
+				case "string":
+					s.Default = ""
+				case "number":
+					s.Default = float32(0)
+				case "integer":
+					s.Default = int32(0)
+				case "boolean":
+					s.Default = false
+				default:
+					// Unknown type, wipe default
+					s.Default = nil
+				}
+			} else if len(s.Ref.String()) > 0 {
+				//!TODO: this does not evaulate wheter a ref might be an object
+				s.Default = nil
+			} else if len(s.AllOf) == 1 && len(s.AllOf[0].Ref.String()) > 0 && !s.AllOf[0].Type.Contains("object") {
+				//!TODO: this does not evaulate wheter a ref might be an object
+				s.Default = nil
+			}
+
+			return true
+		}),
+	},
+}
+
+func applySchemaPatches(k8sVersion int, gv schema.GroupVersion, defName string, schema *spec.Schema) {
+	for _, p := range schemaPatches {
+		if p.MinMinorVersion != 0 && p.MinMinorVersion > k8sVersion {
+			continue
+		} else if p.MaxMinorVersion != 0 && p.MaxMinorVersion < k8sVersion {
+			continue
+		} else if p.AppliesToGV != nil && !p.AppliesToGV(gv) {
+			continue
+		}
+
+		utils.VisitSchema(defName, schema, p.Transformer)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiextensions-apiserver v0.27.0
 	k8s.io/apimachinery v0.27.0
 	k8s.io/apiserver v0.27.0
@@ -90,7 +91,6 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.27.0 // indirect
 	k8s.io/component-base v0.27.0 // indirect

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -79,7 +79,7 @@ func NewRootCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  invoked.Run,
 	}
-	res.Flags().StringVarP(&invoked.version, "version", "", "", "Kubernetes version to validate native resources against. Required if not connected directly to cluster")
+	res.Flags().StringVarP(&invoked.version, "version", "", invoked.version, "Kubernetes version to validate native resources against. Required if not connected directly to cluster")
 	res.Flags().StringVarP(&invoked.localSchemasDir, "local-schemas", "", "", "--local-schemas=./path/to/schemas/dir. Path to a directory with format: /apis/<group>/<version>.json for each group-version's schema.")
 	res.Flags().StringVarP(&invoked.localCRDsDir, "local-crds", "", "", "--local-crds=./path/to/crds/dir. Path to a directory containing .yaml or .yml files for CRD definitions.")
 	res.Flags().StringVarP(&invoked.schemaPatchesDir, "schema-patches", "", "", "Path to a directory with format: /apis/<group>/<version>.json for each group-version's schema you wish to jsonpatch to the groupversion's final schema. Patches only apply if the schema exists")

--- a/pkg/openapiclient/overlay.go
+++ b/pkg/openapiclient/overlay.go
@@ -13,8 +13,15 @@ import (
 //go:embed patches
 var patchesFS embed.FS
 
+//go:embed patches_generated
+var patchesGeneratedFS embed.FS
+
 func HardcodedPatchLoader(version string) groupversion.PatchLoaderFn {
 	return PatchLoaderFromDirectory(patchesFS, filepath.Join("patches", version))
+}
+
+func HardcodedGeneratedPatchLoader(version string) groupversion.PatchLoaderFn {
+	return PatchLoaderFromDirectory(patchesGeneratedFS, filepath.Join("patches_generated", version))
 }
 
 func PatchLoaderFromDirectory(filesystem fs.FS, dir string) groupversion.PatchLoaderFn {

--- a/pkg/openapiclient/patches_generated/1.23/api/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/api/v1.json
@@ -1,0 +1,1262 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenRequestStatus": {
+                "properties": {
+                    "expirationTimestamp": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Binding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatusList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMap": {
+                "properties": {
+                    "binaryData": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateRunning": {
+                "properties": {
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateTerminated": {
+                "properties": {
+                    "finishedAt": {
+                        "default": null
+                    },
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStatus": {
+                "properties": {
+                    "lastState": {
+                        "default": null
+                    },
+                    "state": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointSubset": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "notReadyAddresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Endpoints": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "subsets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointsList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Event": {
+                "properties": {
+                    "eventTime": {
+                        "default": null
+                    },
+                    "firstTimestamp": {
+                        "default": null
+                    },
+                    "involvedObject": {
+                        "default": null
+                    },
+                    "lastTimestamp": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRange": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeItem": {
+                "properties": {
+                    "default": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "defaultRequest": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "max": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "maxLimitRequestRatio": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "min": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeSpec": {
+                "properties": {
+                    "limits": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Namespace": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Node": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeCondition": {
+                "properties": {
+                    "lastHeartbeatTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+                "properties": {
+                    "kubeletEndpoint": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSpec": {
+                "properties": {
+                    "taints": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeStatus": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allocatable": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "daemonEndpoints": {
+                        "default": null
+                    },
+                    "images": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "nodeInfo": {
+                        "default": null
+                    },
+                    "volumesAttached": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolume": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Pod": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "containerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podIPs": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationController": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuota": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaSpec": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaStatus": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "used": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ScopeSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Secret": {
+                "properties": {
+                    "data": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Service": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccount": {
+                "properties": {
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "secrets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccountList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServicePort": {
+                "properties": {
+                    "targetPort": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceSpec": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.Eviction": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/admissionregistration.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/admissionregistration.k8s.io/v1.json
@@ -1,0 +1,170 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1.MutatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/apiextensions.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/apiextensions.k8s.io/v1.json
@@ -1,0 +1,203 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+                "properties": {
+                    "names": {
+                        "default": null
+                    },
+                    "versions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+                "properties": {
+                    "acceptedNames": {
+                        "default": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+                "properties": {
+                    "additionalPrinterColumns": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+                "properties": {
+                    "allOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "anyOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "definitions": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "dependencies": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "enum": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "oneOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "patternProperties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "x-kubernetes-validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/apps/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/apps/v1.json
@@ -1,0 +1,705 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apps.v1.ControllerRevision": {
+                "properties": {
+                    "data": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ControllerRevisionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.Deployment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentSpec": {
+                "properties": {
+                    "strategy": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    },
+                    "volumeClaimTemplates": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/authentication.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/authentication.k8s.io/v1.json
@@ -1,0 +1,67 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenReviewStatus": {
+                "properties": {
+                    "user": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/authorization.k8s.io/v1.json
@@ -1,0 +1,113 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v1.json
@@ -1,0 +1,102 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2beta1.json
@@ -1,0 +1,192 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2beta1.ContainerResourceMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus": {
+                "properties": {
+                    "currentValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ObjectMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    },
+                    "targetValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus": {
+                "properties": {
+                    "currentValue": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.PodsMetricSource": {
+                "properties": {
+                    "targetAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.PodsMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2beta2.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/autoscaling/v2beta2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/batch/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/batch/v1.json
@@ -1,0 +1,521 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.Job": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/batch/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/batch/v1beta1.json
@@ -1,0 +1,477 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/certificates.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/certificates.k8s.io/v1.json
@@ -1,0 +1,148 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1.CertificateSigningRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestSpec": {
+                "properties": {
+                    "request": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestStatus": {
+                "properties": {
+                    "certificate": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/coordination.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/coordination.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.coordination.v1.Lease": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.coordination.v1.LeaseList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/discovery.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/discovery.k8s.io/v1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/discovery.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/discovery.k8s.io/v1beta1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1beta1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/events.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/events.k8s.io/v1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/events.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/events.k8s.io/v1beta1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1beta1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1beta1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1beta1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/internal.apiserver.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/internal.apiserver.k8s.io/v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "storageVersions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/networking.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/networking.k8s.io/v1.json
@@ -1,0 +1,255 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressPath": {
+                "properties": {
+                    "backend": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressRuleValue": {
+                "properties": {
+                    "paths": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.Ingress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressServiceBackend": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressSpec": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressStatus": {
+                "properties": {
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "to": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+                "properties": {
+                    "from": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicySpec": {
+                "properties": {
+                    "egress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podSelector": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1alpha1.json
@@ -1,0 +1,110 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1alpha1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1alpha1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1alpha1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1alpha1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/node.k8s.io/v1beta1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1beta1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/policy/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/policy/v1.json
@@ -1,0 +1,125 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/policy/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/policy/v1beta1.json
@@ -1,0 +1,219 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1beta1.FSGroupStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec": {
+                "properties": {
+                    "allowedCSIDrivers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allowedFlexVolumes": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allowedHostPaths": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "fsGroup": {
+                        "default": null
+                    },
+                    "hostPorts": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "runAsUser": {
+                        "default": null
+                    },
+                    "seLinux": {
+                        "default": null
+                    },
+                    "supplementalGroups": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/rbac.authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/rbac.authorization.k8s.io/v1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.rbac.v1.AggregationRule": {
+                "properties": {
+                    "clusterRoleSelectors": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRole": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.Role": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/scheduling.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/scheduling.k8s.io/v1.json
@@ -1,0 +1,89 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.scheduling.v1.PriorityClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.scheduling.v1.PriorityClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1.json
@@ -1,0 +1,236 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TopologySelectorTerm": {
+                "properties": {
+                    "matchLabelExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriver": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverSpec": {
+                "properties": {
+                    "tokenRequests": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINode": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeSpec": {
+                "properties": {
+                    "drivers": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClass": {
+                "properties": {
+                    "allowedTopologies": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeError": {
+                "properties": {
+                    "time": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1alpha1.json
@@ -1,0 +1,98 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.storage.v1alpha1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1alpha1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.23/apis/storage.k8s.io/v1beta1.json
@@ -1,0 +1,98 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/api/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/api/v1.json
@@ -1,0 +1,1262 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenRequestStatus": {
+                "properties": {
+                    "expirationTimestamp": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Binding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatusList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMap": {
+                "properties": {
+                    "binaryData": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateRunning": {
+                "properties": {
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateTerminated": {
+                "properties": {
+                    "finishedAt": {
+                        "default": null
+                    },
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStatus": {
+                "properties": {
+                    "lastState": {
+                        "default": null
+                    },
+                    "state": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointSubset": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "notReadyAddresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Endpoints": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "subsets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointsList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Event": {
+                "properties": {
+                    "eventTime": {
+                        "default": null
+                    },
+                    "firstTimestamp": {
+                        "default": null
+                    },
+                    "involvedObject": {
+                        "default": null
+                    },
+                    "lastTimestamp": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRange": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeItem": {
+                "properties": {
+                    "default": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "defaultRequest": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "max": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "maxLimitRequestRatio": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "min": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeSpec": {
+                "properties": {
+                    "limits": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Namespace": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Node": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeCondition": {
+                "properties": {
+                    "lastHeartbeatTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+                "properties": {
+                    "kubeletEndpoint": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSpec": {
+                "properties": {
+                    "taints": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeStatus": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allocatable": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "daemonEndpoints": {
+                        "default": null
+                    },
+                    "images": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "nodeInfo": {
+                        "default": null
+                    },
+                    "volumesAttached": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolume": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Pod": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "containerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podIPs": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationController": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuota": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaSpec": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaStatus": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "used": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ScopeSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Secret": {
+                "properties": {
+                    "data": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Service": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccount": {
+                "properties": {
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "secrets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccountList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServicePort": {
+                "properties": {
+                    "targetPort": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceSpec": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.Eviction": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/admissionregistration.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/admissionregistration.k8s.io/v1.json
@@ -1,0 +1,170 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1.MutatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/apiextensions.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/apiextensions.k8s.io/v1.json
@@ -1,0 +1,203 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+                "properties": {
+                    "names": {
+                        "default": null
+                    },
+                    "versions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+                "properties": {
+                    "acceptedNames": {
+                        "default": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+                "properties": {
+                    "additionalPrinterColumns": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+                "properties": {
+                    "allOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "anyOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "definitions": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "dependencies": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "enum": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "oneOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "patternProperties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "x-kubernetes-validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/apps/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/apps/v1.json
@@ -1,0 +1,705 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apps.v1.ControllerRevision": {
+                "properties": {
+                    "data": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ControllerRevisionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.Deployment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentSpec": {
+                "properties": {
+                    "strategy": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    },
+                    "volumeClaimTemplates": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/authentication.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/authentication.k8s.io/v1.json
@@ -1,0 +1,67 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenReviewStatus": {
+                "properties": {
+                    "user": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/authorization.k8s.io/v1.json
@@ -1,0 +1,113 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v1.json
@@ -1,0 +1,102 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2beta1.json
@@ -1,0 +1,192 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2beta1.ContainerResourceMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus": {
+                "properties": {
+                    "currentValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ObjectMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    },
+                    "targetValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus": {
+                "properties": {
+                    "currentValue": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.PodsMetricSource": {
+                "properties": {
+                    "targetAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.PodsMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus": {
+                "properties": {
+                    "currentAverageValue": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2beta2.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/autoscaling/v2beta2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/batch/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/batch/v1.json
@@ -1,0 +1,521 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.Job": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/batch/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/batch/v1beta1.json
@@ -1,0 +1,477 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1beta1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/certificates.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/certificates.k8s.io/v1.json
@@ -1,0 +1,148 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1.CertificateSigningRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestSpec": {
+                "properties": {
+                    "request": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestStatus": {
+                "properties": {
+                    "certificate": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/coordination.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/coordination.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.coordination.v1.Lease": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.coordination.v1.LeaseList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/discovery.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/discovery.k8s.io/v1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/discovery.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/discovery.k8s.io/v1beta1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1beta1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1beta1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/events.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/events.k8s.io/v1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/events.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/events.k8s.io/v1beta1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1beta1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1beta1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1beta1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/internal.apiserver.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/internal.apiserver.k8s.io/v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "storageVersions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/networking.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/networking.k8s.io/v1.json
@@ -1,0 +1,274 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressPath": {
+                "properties": {
+                    "backend": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressRuleValue": {
+                "properties": {
+                    "paths": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.Ingress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressServiceBackend": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressSpec": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressStatus": {
+                "properties": {
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "to": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+                "properties": {
+                    "from": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicySpec": {
+                "properties": {
+                    "egress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podSelector": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/node.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/node.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/node.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/node.k8s.io/v1beta1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1beta1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1beta1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/policy/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/policy/v1.json
@@ -1,0 +1,125 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/policy/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/policy/v1beta1.json
@@ -1,0 +1,219 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1beta1.FSGroupStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec": {
+                "properties": {
+                    "allowedCSIDrivers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allowedFlexVolumes": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allowedHostPaths": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "fsGroup": {
+                        "default": null
+                    },
+                    "hostPorts": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "runAsUser": {
+                        "default": null
+                    },
+                    "seLinux": {
+                        "default": null
+                    },
+                    "supplementalGroups": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions": {
+                "properties": {
+                    "ranges": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/rbac.authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/rbac.authorization.k8s.io/v1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.rbac.v1.AggregationRule": {
+                "properties": {
+                    "clusterRoleSelectors": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRole": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.Role": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/scheduling.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/scheduling.k8s.io/v1.json
@@ -1,0 +1,89 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.scheduling.v1.PriorityClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.scheduling.v1.PriorityClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/storage.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/storage.k8s.io/v1.json
@@ -1,0 +1,264 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TopologySelectorTerm": {
+                "properties": {
+                    "matchLabelExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriver": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverSpec": {
+                "properties": {
+                    "tokenRequests": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINode": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeSpec": {
+                "properties": {
+                    "drivers": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClass": {
+                "properties": {
+                    "allowedTopologies": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeError": {
+                "properties": {
+                    "time": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.24/apis/storage.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.24/apis/storage.k8s.io/v1beta1.json
@@ -1,0 +1,98 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/api/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/api/v1.json
@@ -1,0 +1,1262 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenRequestStatus": {
+                "properties": {
+                    "expirationTimestamp": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Binding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatusList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMap": {
+                "properties": {
+                    "binaryData": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateRunning": {
+                "properties": {
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateTerminated": {
+                "properties": {
+                    "finishedAt": {
+                        "default": null
+                    },
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStatus": {
+                "properties": {
+                    "lastState": {
+                        "default": null
+                    },
+                    "state": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointSubset": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "notReadyAddresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Endpoints": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "subsets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointsList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Event": {
+                "properties": {
+                    "eventTime": {
+                        "default": null
+                    },
+                    "firstTimestamp": {
+                        "default": null
+                    },
+                    "involvedObject": {
+                        "default": null
+                    },
+                    "lastTimestamp": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRange": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeItem": {
+                "properties": {
+                    "default": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "defaultRequest": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "max": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "maxLimitRequestRatio": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "min": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeSpec": {
+                "properties": {
+                    "limits": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Namespace": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Node": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeCondition": {
+                "properties": {
+                    "lastHeartbeatTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+                "properties": {
+                    "kubeletEndpoint": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSpec": {
+                "properties": {
+                    "taints": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeStatus": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allocatable": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "daemonEndpoints": {
+                        "default": null
+                    },
+                    "images": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "nodeInfo": {
+                        "default": null
+                    },
+                    "volumesAttached": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolume": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Pod": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "containerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podIPs": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationController": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuota": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaSpec": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaStatus": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "used": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ScopeSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Secret": {
+                "properties": {
+                    "data": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Service": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccount": {
+                "properties": {
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "secrets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccountList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServicePort": {
+                "properties": {
+                    "targetPort": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceSpec": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.Eviction": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/admissionregistration.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/admissionregistration.k8s.io/v1.json
@@ -1,0 +1,170 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1.MutatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/apiextensions.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/apiextensions.k8s.io/v1.json
@@ -1,0 +1,203 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+                "properties": {
+                    "names": {
+                        "default": null
+                    },
+                    "versions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+                "properties": {
+                    "acceptedNames": {
+                        "default": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+                "properties": {
+                    "additionalPrinterColumns": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+                "properties": {
+                    "allOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "anyOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "definitions": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "dependencies": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "enum": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "oneOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "patternProperties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "x-kubernetes-validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/apps/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/apps/v1.json
@@ -1,0 +1,705 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apps.v1.ControllerRevision": {
+                "properties": {
+                    "data": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ControllerRevisionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.Deployment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentSpec": {
+                "properties": {
+                    "strategy": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    },
+                    "volumeClaimTemplates": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/authentication.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/authentication.k8s.io/v1.json
@@ -1,0 +1,67 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenReviewStatus": {
+                "properties": {
+                    "user": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/authorization.k8s.io/v1.json
@@ -1,0 +1,113 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v1.json
@@ -1,0 +1,102 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v2.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v2beta2.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/autoscaling/v2beta2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/batch/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/batch/v1.json
@@ -1,0 +1,539 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.Job": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicy": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicyRule": {
+                "properties": {
+                    "onPodConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/certificates.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/certificates.k8s.io/v1.json
@@ -1,0 +1,148 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1.CertificateSigningRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestSpec": {
+                "properties": {
+                    "request": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestStatus": {
+                "properties": {
+                    "certificate": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/coordination.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/coordination.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.coordination.v1.Lease": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.coordination.v1.LeaseList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/discovery.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/discovery.k8s.io/v1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/events.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/events.k8s.io/v1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/flowcontrol.apiserver.k8s.io/v1beta1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/internal.apiserver.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/internal.apiserver.k8s.io/v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "storageVersions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/networking.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/networking.k8s.io/v1.json
@@ -1,0 +1,274 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressPath": {
+                "properties": {
+                    "backend": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressRuleValue": {
+                "properties": {
+                    "paths": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.Ingress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressServiceBackend": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressSpec": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressStatus": {
+                "properties": {
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "to": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+                "properties": {
+                    "from": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicySpec": {
+                "properties": {
+                    "egress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podSelector": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/networking.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/networking.k8s.io/v1alpha1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDR": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDRList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/node.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/node.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/policy/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/policy/v1.json
@@ -1,0 +1,125 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/rbac.authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/rbac.authorization.k8s.io/v1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.rbac.v1.AggregationRule": {
+                "properties": {
+                    "clusterRoleSelectors": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRole": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.Role": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/scheduling.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/scheduling.k8s.io/v1.json
@@ -1,0 +1,89 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.scheduling.v1.PriorityClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.scheduling.v1.PriorityClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/storage.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/storage.k8s.io/v1.json
@@ -1,0 +1,264 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TopologySelectorTerm": {
+                "properties": {
+                    "matchLabelExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriver": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverSpec": {
+                "properties": {
+                    "tokenRequests": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINode": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeSpec": {
+                "properties": {
+                    "drivers": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClass": {
+                "properties": {
+                    "allowedTopologies": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeError": {
+                "properties": {
+                    "time": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.25/apis/storage.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.25/apis/storage.k8s.io/v1beta1.json
@@ -1,0 +1,98 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/api/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/api/v1.json
@@ -1,0 +1,1284 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenRequestStatus": {
+                "properties": {
+                    "expirationTimestamp": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Binding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatusList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMap": {
+                "properties": {
+                    "binaryData": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateRunning": {
+                "properties": {
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateTerminated": {
+                "properties": {
+                    "finishedAt": {
+                        "default": null
+                    },
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStatus": {
+                "properties": {
+                    "lastState": {
+                        "default": null
+                    },
+                    "state": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointSubset": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "notReadyAddresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Endpoints": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "subsets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointsList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Event": {
+                "properties": {
+                    "eventTime": {
+                        "default": null
+                    },
+                    "firstTimestamp": {
+                        "default": null
+                    },
+                    "involvedObject": {
+                        "default": null
+                    },
+                    "lastTimestamp": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRange": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeItem": {
+                "properties": {
+                    "default": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "defaultRequest": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "max": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "maxLimitRequestRatio": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "min": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeSpec": {
+                "properties": {
+                    "limits": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Namespace": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Node": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeCondition": {
+                "properties": {
+                    "lastHeartbeatTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+                "properties": {
+                    "kubeletEndpoint": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSpec": {
+                "properties": {
+                    "taints": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeStatus": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allocatable": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "daemonEndpoints": {
+                        "default": null
+                    },
+                    "images": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "nodeInfo": {
+                        "default": null
+                    },
+                    "volumesAttached": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolume": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Pod": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "containerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podIPs": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationController": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuota": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaSpec": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaStatus": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "used": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ScopeSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Secret": {
+                "properties": {
+                    "data": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Service": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccount": {
+                "properties": {
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "secrets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccountList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServicePort": {
+                "properties": {
+                    "targetPort": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceSpec": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.Eviction": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/admissionregistration.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/admissionregistration.k8s.io/v1.json
@@ -1,0 +1,170 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1.MutatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/admissionregistration.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/admissionregistration.k8s.io/v1alpha1.json
@@ -1,0 +1,146 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1alpha1.MatchResources": {
+                "properties": {
+                    "excludeResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicySpec": {
+                "properties": {
+                    "validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/apiextensions.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/apiextensions.k8s.io/v1.json
@@ -1,0 +1,203 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+                "properties": {
+                    "names": {
+                        "default": null
+                    },
+                    "versions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+                "properties": {
+                    "acceptedNames": {
+                        "default": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+                "properties": {
+                    "additionalPrinterColumns": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+                "properties": {
+                    "allOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "anyOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "definitions": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "dependencies": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "enum": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "oneOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "patternProperties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "x-kubernetes-validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/apps/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/apps/v1.json
@@ -1,0 +1,727 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apps.v1.ControllerRevision": {
+                "properties": {
+                    "data": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ControllerRevisionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.Deployment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentSpec": {
+                "properties": {
+                    "strategy": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    },
+                    "volumeClaimTemplates": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/authentication.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/authentication.k8s.io/v1.json
@@ -1,0 +1,67 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenReviewStatus": {
+                "properties": {
+                    "user": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/authentication.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/authentication.k8s.io/v1alpha1.json
@@ -1,0 +1,64 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1alpha1.SelfSubjectReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1alpha1.SelfSubjectReviewStatus": {
+                "properties": {
+                    "userInfo": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/authorization.k8s.io/v1.json
@@ -1,0 +1,113 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/autoscaling/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/autoscaling/v1.json
@@ -1,0 +1,102 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/autoscaling/v2.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/autoscaling/v2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/batch/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/batch/v1.json
@@ -1,0 +1,561 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.Job": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicy": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicyRule": {
+                "properties": {
+                    "onPodConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/certificates.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/certificates.k8s.io/v1.json
@@ -1,0 +1,148 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1.CertificateSigningRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestSpec": {
+                "properties": {
+                    "request": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestStatus": {
+                "properties": {
+                    "certificate": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/coordination.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/coordination.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.coordination.v1.Lease": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.coordination.v1.LeaseList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/discovery.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/discovery.k8s.io/v1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/events.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/events.k8s.io/v1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/flowcontrol.apiserver.k8s.io/v1beta3.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/flowcontrol.apiserver.k8s.io/v1beta3.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/internal.apiserver.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/internal.apiserver.k8s.io/v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "storageVersions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/networking.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/networking.k8s.io/v1.json
@@ -1,0 +1,274 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.networking.v1.HTTPIngressPath": {
+                "properties": {
+                    "backend": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressRuleValue": {
+                "properties": {
+                    "paths": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.Ingress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressLoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressLoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressServiceBackend": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressSpec": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressStatus": {
+                "properties": {
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "to": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+                "properties": {
+                    "from": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicySpec": {
+                "properties": {
+                    "egress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podSelector": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/networking.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/networking.k8s.io/v1alpha1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDR": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDRList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/node.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/node.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/policy/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/policy/v1.json
@@ -1,0 +1,125 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/rbac.authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/rbac.authorization.k8s.io/v1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.rbac.v1.AggregationRule": {
+                "properties": {
+                    "clusterRoleSelectors": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRole": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.Role": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/resource.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/resource.k8s.io/v1alpha1.json
@@ -1,0 +1,212 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.PodScheduling": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.PodSchedulingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.PodSchedulingStatus": {
+                "properties": {
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaimStatus": {
+                "properties": {
+                    "reservedFor": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaimTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClaimTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha1.ResourceClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/scheduling.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/scheduling.k8s.io/v1.json
@@ -1,0 +1,89 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.scheduling.v1.PriorityClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.scheduling.v1.PriorityClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/storage.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/storage.k8s.io/v1.json
@@ -1,0 +1,264 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TopologySelectorTerm": {
+                "properties": {
+                    "matchLabelExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriver": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverSpec": {
+                "properties": {
+                    "tokenRequests": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINode": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeSpec": {
+                "properties": {
+                    "drivers": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClass": {
+                "properties": {
+                    "allowedTopologies": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeError": {
+                "properties": {
+                    "time": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.26/apis/storage.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.26/apis/storage.k8s.io/v1beta1.json
@@ -1,0 +1,98 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1beta1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/api/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/api/v1.json
@@ -1,0 +1,1299 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenRequestStatus": {
+                "properties": {
+                    "expirationTimestamp": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Binding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ComponentStatusList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMap": {
+                "properties": {
+                    "binaryData": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateRunning": {
+                "properties": {
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStateTerminated": {
+                "properties": {
+                    "finishedAt": {
+                        "default": null
+                    },
+                    "startedAt": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ContainerStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "lastState": {
+                        "default": null
+                    },
+                    "state": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointSubset": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "notReadyAddresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Endpoints": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "subsets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EndpointsList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Event": {
+                "properties": {
+                    "eventTime": {
+                        "default": null
+                    },
+                    "firstTimestamp": {
+                        "default": null
+                    },
+                    "involvedObject": {
+                        "default": null
+                    },
+                    "lastTimestamp": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRange": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeItem": {
+                "properties": {
+                    "default": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "defaultRequest": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "max": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "maxLimitRequestRatio": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "min": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LimitRangeSpec": {
+                "properties": {
+                    "limits": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.LoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Namespace": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NamespaceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Node": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeCondition": {
+                "properties": {
+                    "lastHeartbeatTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+                "properties": {
+                    "kubeletEndpoint": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSpec": {
+                "properties": {
+                    "taints": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeStatus": {
+                "properties": {
+                    "addresses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "allocatable": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "daemonEndpoints": {
+                        "default": null
+                    },
+                    "images": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "nodeInfo": {
+                        "default": null
+                    },
+                    "volumesAttached": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolume": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Pod": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "containerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainerStatuses": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podIPs": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationController": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ReplicationControllerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuota": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaSpec": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceQuotaStatus": {
+                "properties": {
+                    "hard": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "used": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ScopeSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Secret": {
+                "properties": {
+                    "data": {
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "anyOf": [
+                                        {
+                                            "format": "byte"
+                                        },
+                                        {
+                                            "maxLength": 0
+                                        }
+                                    ]
+                                }
+                            ],
+                            "format": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Service": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccount": {
+                "properties": {
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "secrets": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceAccountList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServicePort": {
+                "properties": {
+                    "targetPort": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceSpec": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ServiceStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.Eviction": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/admissionregistration.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/admissionregistration.k8s.io/v1.json
@@ -1,0 +1,180 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1.MutatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "matchConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhook": {
+                "properties": {
+                    "clientConfig": {
+                        "default": null
+                    },
+                    "matchConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "webhooks": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/admissionregistration.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/admissionregistration.k8s.io/v1alpha1.json
@@ -1,0 +1,184 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.admissionregistration.v1alpha1.MatchResources": {
+                "properties": {
+                    "excludeResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.TypeChecking": {
+                "properties": {
+                    "expressionWarnings": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicySpec": {
+                "properties": {
+                    "auditAnnotations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/apiextensions.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/apiextensions.k8s.io/v1.json
@@ -1,0 +1,203 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+                "properties": {
+                    "names": {
+                        "default": null
+                    },
+                    "versions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+                "properties": {
+                    "acceptedNames": {
+                        "default": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+                "properties": {
+                    "additionalPrinterColumns": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+                "properties": {
+                    "allOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "anyOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "definitions": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "dependencies": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "enum": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "oneOf": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "patternProperties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "properties": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "x-kubernetes-validations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+                "properties": {
+                    "caBundle": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/apps/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/apps/v1.json
@@ -1,0 +1,737 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apps.v1.ControllerRevision": {
+                "properties": {
+                    "data": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ControllerRevisionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DaemonSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.Deployment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentSpec": {
+                "properties": {
+                    "strategy": {
+                        "default": null
+                    },
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.DeploymentStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.ReplicaSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSet": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    },
+                    "updateStrategy": {
+                        "default": null
+                    },
+                    "volumeClaimTemplates": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.apps.v1.StatefulSetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.Scale": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+                "properties": {
+                    "allocatedResources": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1.json
@@ -1,0 +1,67 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1.TokenReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1.TokenReviewStatus": {
+                "properties": {
+                    "user": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1alpha1.json
@@ -1,0 +1,64 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1alpha1.SelfSubjectReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1alpha1.SelfSubjectReviewStatus": {
+                "properties": {
+                    "userInfo": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1beta1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/authentication.k8s.io/v1beta1.json
@@ -1,0 +1,64 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authentication.v1beta1.SelfSubjectReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authentication.v1beta1.SelfSubjectReviewStatus": {
+                "properties": {
+                    "userInfo": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/authorization.k8s.io/v1.json
@@ -1,0 +1,113 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectAccessReview": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/autoscaling/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/autoscaling/v1.json
@@ -1,0 +1,102 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/autoscaling/v2.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/autoscaling/v2.json
@@ -1,0 +1,240 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ExternalMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+                "properties": {
+                    "metrics": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "scaleTargetRef": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "currentMetrics": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+                "properties": {
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ObjectMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "describedObject": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+                "properties": {
+                    "metric": {
+                        "default": null
+                    },
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.PodsMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    },
+                    "metric": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+                "properties": {
+                    "target": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.autoscaling.v2.ResourceMetricStatus": {
+                "properties": {
+                    "current": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/batch/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/batch/v1.json
@@ -1,0 +1,571 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.batch.v1.CronJob": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobSpec": {
+                "properties": {
+                    "jobTemplate": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.CronJobStatus": {
+                "properties": {
+                    "active": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.Job": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobCondition": {
+                "properties": {
+                    "lastProbeTime": {
+                        "default": null
+                    },
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobSpec": {
+                "properties": {
+                    "template": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.JobTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicy": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.batch.v1.PodFailurePolicyRule": {
+                "properties": {
+                    "onPodConditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.Container": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.EphemeralContainer": {
+                "properties": {
+                    "env": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "envFrom": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resizePolicy": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resources": {
+                        "default": null
+                    },
+                    "volumeDevices": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumeMounts": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.HTTPGetAction": {
+                "properties": {
+                    "httpHeaders": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+                "properties": {
+                    "resources": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodAntiAffinity": {
+                "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodDNSConfig": {
+                "properties": {
+                    "options": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodResourceClaim": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSecurityContext": {
+                "properties": {
+                    "sysctls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodSpec": {
+                "properties": {
+                    "containers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ephemeralContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "hostAliases": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "imagePullSecrets": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "initContainers": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "overhead": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "readinessGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "schedulingGates": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "topologySpreadConstraints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "volumes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PodTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+                "properties": {
+                    "preference": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ProjectedVolumeSource": {
+                "properties": {
+                    "sources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceFieldSelector": {
+                "properties": {
+                    "divisor": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.ResourceRequirements": {
+                "properties": {
+                    "claims": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "limits": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    },
+                    "requests": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretProjection": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.SecretVolumeSource": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TCPSocketAction": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+                "properties": {
+                    "podAffinityTerm": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/certificates.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/certificates.k8s.io/v1.json
@@ -1,0 +1,148 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1.CertificateSigningRequest": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    },
+                    "lastUpdateTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestSpec": {
+                "properties": {
+                    "request": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1.CertificateSigningRequestStatus": {
+                "properties": {
+                    "certificate": {
+                        "allOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "format": "byte"
+                                    },
+                                    {
+                                        "maxLength": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "format": null
+                    },
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/certificates.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/certificates.k8s.io/v1alpha1.json
@@ -1,0 +1,92 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.certificates.v1alpha1.ClusterTrustBundle": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.certificates.v1alpha1.ClusterTrustBundleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/coordination.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/coordination.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.coordination.v1.Lease": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.coordination.v1.LeaseList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/discovery.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/discovery.k8s.io/v1.json
@@ -1,0 +1,115 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.discovery.v1.Endpoint": {
+                "properties": {
+                    "conditions": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointHints": {
+                "properties": {
+                    "forZones": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSlice": {
+                "properties": {
+                    "endpoints": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.discovery.v1.EndpointSliceList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/events.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/events.k8s.io/v1.json
@@ -1,0 +1,126 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.events.v1.Event": {
+                "properties": {
+                    "deprecatedFirstTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedLastTimestamp": {
+                        "default": null
+                    },
+                    "deprecatedSource": {
+                        "default": null
+                    },
+                    "eventTime": {
+                        "default": null
+                    },
+                    "metadata": {
+                        "default": null
+                    },
+                    "regarding": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.events.v1.EventSeries": {
+                "properties": {
+                    "lastObservedTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/flowcontrol.apiserver.k8s.io/v1beta2.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/flowcontrol.apiserver.k8s.io/v1beta3.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/flowcontrol.apiserver.k8s.io/v1beta3.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchema": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaSpec": {
+                "properties": {
+                    "priorityLevelConfiguration": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.FlowSchemaStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.LimitedPriorityLevelConfiguration": {
+                "properties": {
+                    "limitResponse": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PolicyRulesWithSubjects": {
+                "properties": {
+                    "nonResourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "resourceRules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfiguration": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/internal.apiserver.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/internal.apiserver.k8s.io/v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "storageVersions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/networking.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/networking.k8s.io/v1.json
@@ -1,0 +1,274 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.networking.v1.HTTPIngressPath": {
+                "properties": {
+                    "backend": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.HTTPIngressRuleValue": {
+                "properties": {
+                    "paths": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.Ingress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressLoadBalancerIngress": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressLoadBalancerStatus": {
+                "properties": {
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressServiceBackend": {
+                "properties": {
+                    "port": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressSpec": {
+                "properties": {
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "tls": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.IngressStatus": {
+                "properties": {
+                    "loadBalancer": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicy": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
+                "properties": {
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "to": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
+                "properties": {
+                    "from": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ports": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicySpec": {
+                "properties": {
+                    "egress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ingress": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "podSelector": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1.NetworkPolicyStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/networking.k8s.io/v1alpha1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/networking.k8s.io/v1alpha1.json
@@ -1,0 +1,137 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDR": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.ClusterCIDRList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.IPAddress": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.networking.v1alpha1.IPAddressList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/node.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/node.k8s.io/v1.json
@@ -1,0 +1,107 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.node.v1.Overhead": {
+                "properties": {
+                    "podFixed": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.RuntimeClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.node.v1.Scheduling": {
+                "properties": {
+                    "tolerations": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/policy/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/policy/v1.json
@@ -1,0 +1,125 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.policy.v1.PodDisruptionBudget": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+                "properties": {
+                    "conditions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "disruptedPods": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+                "properties": {
+                    "lastTransitionTime": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/rbac.authorization.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/rbac.authorization.k8s.io/v1.json
@@ -1,0 +1,190 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.rbac.v1.AggregationRule": {
+                "properties": {
+                    "clusterRoleSelectors": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRole": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.ClusterRoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.Role": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "rules": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBinding": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "roleRef": {
+                        "default": null
+                    },
+                    "subjects": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleBindingList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.rbac.v1.RoleList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/resource.k8s.io/v1alpha2.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/resource.k8s.io/v1alpha2.json
@@ -1,0 +1,221 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.AllocationResult": {
+                "properties": {
+                    "resourceHandles": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.PodSchedulingContext": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.PodSchedulingContextList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.PodSchedulingContextStatus": {
+                "properties": {
+                    "resourceClaims": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaim": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaimList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaimStatus": {
+                "properties": {
+                    "reservedFor": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaimTemplate": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaimTemplateList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClaimTemplateSpec": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.resource.v1alpha2.ResourceClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/scheduling.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/scheduling.k8s.io/v1.json
@@ -1,0 +1,89 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.scheduling.v1.PriorityClass": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.scheduling.v1.PriorityClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/openapiclient/patches_generated/1.27/apis/storage.k8s.io/v1.json
+++ b/pkg/openapiclient/patches_generated/1.27/apis/storage.k8s.io/v1.json
@@ -1,0 +1,264 @@
+{
+    "components": {
+        "schemas": {
+            "io.k8s.api.core.v1.NodeSelector": {
+                "properties": {
+                    "nodeSelectorTerms": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.NodeSelectorTerm": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "matchFields": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.PersistentVolumeSpec": {
+                "properties": {
+                    "capacity": {
+                        "additionalProperties": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.core.v1.TopologySelectorTerm": {
+                "properties": {
+                    "matchLabelExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriver": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIDriverSpec": {
+                "properties": {
+                    "tokenRequests": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINode": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSINodeSpec": {
+                "properties": {
+                    "drivers": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacity": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.CSIStorageCapacityList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClass": {
+                "properties": {
+                    "allowedTopologies": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.StorageClassList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachment": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    },
+                    "spec": {
+                        "default": null
+                    },
+                    "status": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentList": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeAttachmentSpec": {
+                "properties": {
+                    "source": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.api.storage.v1.VolumeError": {
+                "properties": {
+                    "time": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+                "properties": {
+                    "resources": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+                "properties": {
+                    "matchExpressions": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+                "properties": {
+                    "creationTimestamp": {
+                        "default": null
+                    },
+                    "managedFields": {
+                        "items": {
+                            "default": null
+                        }
+                    },
+                    "ownerReferences": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+                "properties": {
+                    "metadata": {
+                        "default": null
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+                "properties": {
+                    "causes": {
+                        "items": {
+                            "default": null
+                        }
+                    }
+                }
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "format": "date-time"
+                            },
+                            {
+                                "maxLength": 0
+                            }
+                        ]
+                    }
+                ],
+                "format": null
+            },
+            "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+                "properties": {
+                    "object": {
+                        "default": null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/utils/schema_visitor.go
+++ b/pkg/utils/schema_visitor.go
@@ -1,0 +1,148 @@
+package utils
+
+import (
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// There is no "left" or "right" on this tree, so no in-order is necessary
+type PreorderVisitor func(ctx VisitingContext, s *spec.Schema) bool
+type PostorderVisitor func(ctx VisitingContext, s *spec.Schema) bool
+
+func (f PreorderVisitor) VisitBefore(ctx VisitingContext, s **spec.Schema) {
+	if !f(ctx, *s) {
+		*s = nil
+	}
+}
+func (f PreorderVisitor) VisitAfter(ctx VisitingContext, s **spec.Schema) {}
+
+func (f PostorderVisitor) VisitBefore(ctx VisitingContext, s **spec.Schema) {}
+func (f PostorderVisitor) VisitAfter(ctx VisitingContext, s **spec.Schema) {
+	if !f(ctx, *s) {
+		*s = nil
+	}
+}
+
+type VisitingContext struct {
+	// What field of the parent context was traversed to find the current
+	// schema
+	SchemaField string
+
+	// If ShemaField is a collection, what key is this schema contained within
+	// SchemaField
+	Key string
+
+	// If ShemaField is a collection, what index is this schema contained within
+	// SchemaField
+	//
+	// Part of a Union with `key` If one is set, the other must be unset
+	Index int
+
+	Parent *VisitingContext
+}
+
+func (v *VisitingContext) WithSubField(field, key string) VisitingContext {
+	return VisitingContext{
+		Parent:      v,
+		SchemaField: field,
+		Key:         key,
+	}
+}
+
+func (v *VisitingContext) WithSubIndex(field string, idx int) VisitingContext {
+	return VisitingContext{
+		Parent:      v,
+		SchemaField: field,
+		Index:       idx,
+	}
+}
+
+type SchemaVisitor interface {
+	VisitBefore(ctx VisitingContext, s **spec.Schema)
+	VisitAfter(ctx VisitingContext, s **spec.Schema)
+}
+
+func VisitSchema(name string, s *spec.Schema, visitor SchemaVisitor) {
+	visitSchema(&s, visitor, VisitingContext{
+		SchemaField: "schemas",
+		Key:         name,
+	})
+}
+
+func visitSchema(s **spec.Schema, visitor SchemaVisitor, context VisitingContext) {
+	if s == nil {
+		return
+	}
+
+	visitor.VisitBefore(context, s)
+	if s := *s; s != nil {
+		for k, v := range s.Properties {
+			pV := &v
+			visitSchema(&pV, visitor, context.WithSubField("properties", k))
+
+			if pV == nil {
+				delete(s.Properties, k)
+			} else {
+				s.Properties[k] = *pV
+			}
+		}
+
+		for k, v := range s.PatternProperties {
+			pV := &v
+			visitSchema(&pV, visitor, context.WithSubField("patternProperties", k))
+
+			if pV == nil {
+				delete(s.PatternProperties, k)
+			} else {
+				s.PatternProperties[k] = *pV
+			}
+		}
+
+		for k, v := range s.AllOf {
+			pV := &v
+			visitSchema(&pV, visitor, context.WithSubIndex("allOf", k))
+			s.AllOf[k] = *pV
+		}
+
+		for k, v := range s.AnyOf {
+			pV := &v
+			visitSchema(&pV, visitor, context.WithSubIndex("anyOf", k))
+			s.AnyOf[k] = *pV
+		}
+
+		for k, v := range s.OneOf {
+			pV := &v
+			visitSchema(&pV, visitor, context.WithSubIndex("oneOf", k))
+			s.OneOf[k] = *pV
+		}
+
+		if s.Not != nil {
+			visitSchema(&s.Not, visitor, context.WithSubField("not", ""))
+		}
+
+		if soa := s.Items; soa != nil {
+			if soa.Schema != nil {
+				visitSchema(&soa.Schema, visitor, context.WithSubIndex("items", 0))
+			}
+
+			for k, v := range soa.Schemas {
+				pV := &v
+				visitSchema(&pV, visitor, context.WithSubIndex("items", k))
+				soa.Schemas[k] = *pV
+			}
+
+		}
+
+		if a := s.AdditionalProperties; a != nil {
+			if a.Schema != nil {
+				visitSchema(&a.Schema, visitor, context.WithSubField("additionalProperties", ""))
+			}
+		}
+
+		if a := s.AdditionalItems; a != nil {
+			if a.Schema != nil {
+				visitSchema(&a.Schema, visitor, context.WithSubField("additionalItems", ""))
+			}
+		}
+	}
+	visitor.VisitAfter(context, s)
+}

--- a/testcases/manifests/deployment_with_strategy.yaml
+++ b/testcases/manifests/deployment_with_strategy.yaml
@@ -1,0 +1,39 @@
+# {
+#     "status": "Success",
+#     "message": ""
+# }
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      service: my-service
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        service: my-service
+    spec:
+       containers:
+        - name: main
+          image: my-service:latest
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP

--- a/testcases/manifests/empty_secret.yaml
+++ b/testcases/manifests/empty_secret.yaml
@@ -1,0 +1,10 @@
+# {
+#     "status": "Success",
+#     "message": ""
+# }
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+data:
+  key: ''

--- a/testcases/manifests/error_multiple_fields.yaml
+++ b/testcases/manifests/error_multiple_fields.yaml
@@ -1,0 +1,25 @@
+# {
+#     "metadata": {},
+#     "status": "Failure",
+#     "message": "failed to unmarshal document to YAML",
+#     "reason": "BadRequest",
+#     "details": {
+#         "causes": [
+#             {
+#                 "message": "line 24: key \"containers\" already set in map"
+#             }
+#         ]
+#     },
+#     "code": 400
+# }
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+  - name: my-container
+    image: my-image:latest
+  containers:
+  - name: my-container
+    image: my-image:latest

--- a/testcases/manifests/error_name_exceeds_max_length.yaml
+++ b/testcases/manifests/error_name_exceeds_max_length.yaml
@@ -1,0 +1,25 @@
+# {
+#   "metadata": {},
+#   "status": "Failure",
+#   "message": "ConfigMap.core \"thisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongname\" is invalid: metadata.name: Invalid value: \"thisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongname\": must be no more than 253 characters",
+#   "reason": "Invalid",
+#   "details": {
+#     "name": "thisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongname",
+#     "group": "core",
+#     "kind": "ConfigMap",
+#     "causes": [
+#       {
+#         "reason": "FieldValueInvalid",
+#         "message": "Invalid value: \"thisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongname\": must be no more than 253 characters",
+#         "field": "metadata.name"
+#       }
+#     ]
+#   },
+#   "code": 422
+# }
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongnamethisisaveryveryveryveryveryveryverylongname
+data:
+  key: value


### PR DESCRIPTION
Adds some code to the native schema downloader that also generates patches to workaround known deficiencies in native schema.

Fixes #60

Currently included patches:

1. Allow empty `byte` format strings
2. Allow empty `date-time` format strings
3. Remove `default: {}` where it does not make sense