### PR TITLE
Return the error that ReadDir returns in localSchemasClient.Paths

### DIFF
--- a/pkg/openapiclient/local_schemas_test.go
+++ b/pkg/openapiclient/local_schemas_test.go
@@ -137,6 +137,11 @@ func Test_localSchemasClient_Paths(t *testing.T) {
 		fs:   os.DirFS("../../invalid"),
 		dir:  ".",
 		want: sets.New[string](),
+	}, {
+		name:    "not a dir",
+		fs:      os.DirFS("../../testcases/schemas"),
+		dir:     "error_not_a_dir",
+		wantErr: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #75 

If ReadDir returns an error except for fs.ErrNotExist, localSchemasClient.Paths returns the error with an additional message.