### PR TITLE
Supply structural schema without version map

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -11,8 +11,6 @@ import (
 
 	"golang.org/x/exp/maps"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -121,11 +119,7 @@ func (s *Validator) Validate(obj *unstructured.Unstructured) error {
 	}
 
 	strat := customresource.NewStrategy(validators.ObjectTyper(gvk), isNamespaced, gvk, validators.SchemaValidator(), nil,
-		&structuralschema.Structural{
-			Properties: map[string]apiextensionsschema.Structural{
-				gvk.Version: *ss,
-			},
-		},
+		ss,
 		nil, nil)
 
 	rest.FillObjectMetaSystemFields(obj)


### PR DESCRIPTION
Bug was introduced in #81 that got past review. This change correctly supplies the structural schema. (Version map is no longer required due to https://github.com/kubernetes/kubernetes/pull/121337)