### PR TITLE
Allow flag local-crds to take a crd file as input

### DIFF
--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -59,7 +59,7 @@ type commandFlags struct {
 	kubeConfigOverrides clientcmd.ConfigOverrides
 	version             string
 	localSchemasDir     string
-	localCRDsDir        string
+	localCRDsPath       string
 	schemaPatchesDir    string
 	outputFormat        OutputFormat
 }
@@ -79,7 +79,7 @@ func NewRootCommand() *cobra.Command {
 	}
 	res.Flags().StringVarP(&invoked.version, "version", "", invoked.version, "Kubernetes version to validate native resources against. Required if not connected directly to cluster")
 	res.Flags().StringVarP(&invoked.localSchemasDir, "local-schemas", "", "", "--local-schemas=./path/to/schemas/dir. Path to a directory with format: /apis/<group>/<version>.json for each group-version's schema.")
-	res.Flags().StringVarP(&invoked.localCRDsDir, "local-crds", "", "", "--local-crds=./path/to/crds/dir. Path to a directory containing .yaml or .yml files for CRD definitions.")
+	res.Flags().StringVarP(&invoked.localCRDsPath, "local-crds", "", "", "--local-crds=./path/to/crds/dir[/crd.yaml]. Path to a directory containing .yaml or .yml files for CRD definitions or path to the CRD definition file.")
 	res.Flags().StringVarP(&invoked.schemaPatchesDir, "schema-patches", "", "", "Path to a directory with format: /apis/<group>/<version>.json for each group-version's schema you wish to jsonpatch to the groupversion's final schema. Patches only apply if the schema exists")
 	res.Flags().VarP(&invoked.outputFormat, "output", "o", "Output format. Choice of: \"human\" or \"json\"")
 	clientcmd.BindOverrideFlags(&invoked.kubeConfigOverrides, res.Flags(), clientcmd.RecommendedConfigOverrideFlags("kube-"))
@@ -173,7 +173,7 @@ func (c *commandFlags) Run(cmd *cobra.Command, args []string) error {
 				// consult local OpenAPI
 				openapiclient.NewLocalSchemaFiles(nil, c.localSchemasDir),
 				// consult local CRDs
-				openapiclient.NewLocalCRDFiles(nil, c.localCRDsDir),
+				openapiclient.NewLocalCRDFiles(nil, c.localCRDsPath),
 				openapiclient.NewOverlay(
 					// Hand-written hardcoded patches.
 					openapiclient.HardcodedPatchLoader(c.version),

--- a/pkg/openapiclient/local_crds_test.go
+++ b/pkg/openapiclient/local_crds_test.go
@@ -14,18 +14,18 @@ import (
 
 func TestNewLocalCRDFiles(t *testing.T) {
 	tests := []struct {
-		name    string
-		fs      fs.FS
-		dirPath string
-		want    openapi.Client
+		name string
+		fs   fs.FS
+		path string
+		want openapi.Client
 	}{{
 		name: "fs nil and dir empty",
 		want: &localCRDsClient{},
 	}, {
-		name:    "only dir",
-		dirPath: "test",
+		name: "only dir",
+		path: "test",
 		want: &localCRDsClient{
-			dir: "test",
+			path: "test",
 		},
 	}, {
 		name: "only fs",
@@ -34,17 +34,17 @@ func TestNewLocalCRDFiles(t *testing.T) {
 			fs: os.DirFS("."),
 		},
 	}, {
-		name:    "both fs and dir",
-		fs:      os.DirFS("."),
-		dirPath: "test",
+		name: "both fs and dir",
+		fs:   os.DirFS("."),
+		path: "test",
 		want: &localCRDsClient{
-			fs:  os.DirFS("."),
-			dir: "test",
+			fs:   os.DirFS("."),
+			path: "test",
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewLocalCRDFiles(tt.fs, tt.dirPath)
+			got := NewLocalCRDFiles(tt.fs, tt.path)
 			require.Equal(t, tt.want, got, "NewLocalCRDFiles not equal")
 		})
 	}
@@ -54,14 +54,14 @@ func Test_localCRDsClient_Paths(t *testing.T) {
 	tests := []struct {
 		name    string
 		fs      fs.FS
-		dir     string
+		path    string
 		want    map[string]sets.Set[string]
 		wantErr bool
 	}{{
 		name: "fs nil and dir empty",
 	}, {
 		name: "only dir",
-		dir:  "../../testcases/crds",
+		path: "../../testcases/crds",
 		want: map[string]sets.Set[string]{
 			"apis/batch.x-k8s.io/v1alpha1": sets.New(
 				"batch.x-k8s.io/v1alpha1.JobSet",
@@ -86,7 +86,7 @@ func Test_localCRDsClient_Paths(t *testing.T) {
 	}, {
 		name: "both fs and dir",
 		fs:   os.DirFS("../../testcases"),
-		dir:  "crds",
+		path: "crds",
 		want: map[string]sets.Set[string]{
 			"apis/batch.x-k8s.io/v1alpha1": sets.New(
 				"batch.x-k8s.io/v1alpha1.JobSet",
@@ -106,18 +106,26 @@ func Test_localCRDsClient_Paths(t *testing.T) {
 			),
 		},
 	}, {
+		name: "path is a file",
+		path: "../../testcases/crds/cel_basic.yaml",
+		want: map[string]sets.Set[string]{
+			"apis/stable.example.com/v1": sets.New(
+				"stable.example.com/v1.CELBasic",
+			),
+		},
+	}, {
 		name:    "invalid dir",
-		dir:     "invalid",
+		path:    "invalid",
 		wantErr: true,
 	}, {
 		name:    "invalid fs",
 		fs:      os.DirFS("../../invalid"),
-		dir:     ".",
+		path:    ".",
 		wantErr: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k := NewLocalCRDFiles(tt.fs, tt.dir)
+			k := NewLocalCRDFiles(tt.fs, tt.path)
 			paths, err := k.Paths()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("localCRDsClient.Paths() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR allows flag `local-crds` to take a crd file instead of a folder as input

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The flag `local-crds` can take a file instead of a folder as input now.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```