### PR TITLE
feat: support multiple document yaml files

### DIFF
--- a/pkg/cmd/validate_test.go
+++ b/pkg/cmd/validate_test.go
@@ -50,11 +50,12 @@ func TestValidationErrorsIndividually(t *testing.T) {
 			documents, err := utils.SplitYamlDocuments(data)
 			require.NoError(t, err)
 
-			var expected []metav1.Status
+			var expected [][]metav1.Status
 			expectedError := false
 			for _, document := range documents {
+				docExpected := []metav1.Status{}
 				if utils.IsEmptyYamlDocument(document) {
-					expected = append(expected, metav1.Status{Status: metav1.StatusSuccess})
+					docExpected = append(docExpected, metav1.Status{Status: metav1.StatusSuccess})
 				} else {
 					lines := strings.Split(string(document), "\n")
 
@@ -77,11 +78,12 @@ func TestValidationErrorsIndividually(t *testing.T) {
 						t.Fatalf("error parsing leading expectation comment: %v", err)
 					}
 
-					expected = append(expected, expectation)
+					docExpected = append(docExpected, expectation)
 					if expectation.Status != "Success" {
 						expectedError = true
 					}
 				}
+				expected = append(expected, docExpected)
 			}
 
 			rootCmd := cmd.NewRootCommand()
@@ -101,7 +103,7 @@ func TestValidationErrorsIndividually(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			output := map[string][]metav1.Status{}
+			output := map[string][][]metav1.Status{}
 			if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/utils/yaml.go
+++ b/pkg/utils/yaml.go
@@ -12,6 +12,24 @@ import (
 type Document = []byte
 
 func SplitYamlDocuments(fileBytes Document) ([]Document, error) {
+	var toRead int = len(fileBytes)
+	var documents []Document
+	decoder := utilyaml.NewDocumentDecoder(io.NopCloser(bufio.NewReader(bytes.NewBuffer(fileBytes))))
+	for {
+		document := make(Document, toRead)
+		n, err := decoder.Read(document)
+		if err == io.EOF || len(document) == 0 {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		documents = append(documents, Document(document[0:n]))
+		toRead -= n
+	}
+	return documents, nil
+}
+
+func SplitYamlDocuments1(fileBytes Document) ([]Document, error) {
 	var documents [][]byte
 	reader := utilyaml.NewYAMLReader(bufio.NewReader(bytes.NewBuffer(fileBytes)))
 	for {

--- a/pkg/utils/yaml_test.go
+++ b/pkg/utils/yaml_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitDocuments(t *testing.T) {
+	cases := []struct {
+		name          string
+		input         []byte
+		expected      []Document
+		expectedError string
+	}{
+		{
+			name:  "single document",
+			input: []byte(`{"key": "value","name":"doc1"}`),
+			expected: []Document{
+				Document([]byte(`{"key": "value","name":"doc1"}`)),
+			},
+		},
+		{
+			name:  "multiple documents",
+			input: []byte(`{"key": "value","name":"doc1"}` + "\n---\n" + `{"key": "value","name":"doc2"}`),
+			expected: []Document{
+				Document([]byte(`{"key": "value","name":"doc1"}`)),
+				Document([]byte(`{"key": "value","name":"doc2"}`)),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SplitYamlDocuments(tc.input)
+			if tc.expectedError != "" {
+				require.ErrorContains(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				for i := range actual {
+					require.Equal(t, string(tc.expected[i]), string(actual[i]))
+				}
+				require.Len(t, actual, len(tc.expected))
+			}
+		})
+	}
+}

--- a/testcases/manifests/configmap_multi.yaml
+++ b/testcases/manifests/configmap_multi.yaml
@@ -1,0 +1,36 @@
+# {
+#     "status": "Success",
+#     "message": ""
+# }
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: successful
+data:
+  key: "123"
+---
+# {
+#   "metadata": {},
+#   "status": "Failure",
+#   "message": "ConfigMap.core \"failure\" is invalid: data.key: Invalid value: \"integer\": data.key in body must be of type string: \"integer\"",
+#   "reason": "Invalid",
+#   "details": {
+#     "name": "failure",
+#     "group": "core",
+#     "kind": "ConfigMap",
+#     "causes": [
+#       {
+#         "reason": "FieldValueTypeInvalid",
+#         "message": "Invalid value: \"integer\": data.key in body must be of type string: \"integer\"",
+#         "field": "data.key"
+#       }
+#     ]
+#   },
+#   "code": 422
+# }
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: failure
+data:
+  key: 123


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #123

#### Special notes for your reviewer:

- (Option 1) This introduces a breaking change in the output, in the initial draft. _Something_ needs to represent the additional detail.

```json
{
    "/tmp/foo.yaml": [
        [
            { // doc one
                "metadata": {},
                "status": "Success"
            }
        ],
        [
            { // doc two
                "metadata": {},
                "status": "Failure",
```

- ~~(Option 2) An alternative would be to ensure that the "metadata" of the status object includes the right detail:~~
<details>
<summary>example</summary>

```json
{
    "/tmp/foo.yaml": [
            { // doc one
                "kind": "...",
                "apiVersion": "...",
                "name": "...",
                "status": "Success"
                "details": {
                  "name: "..."
                }
            },
            { // doc two
                "kind": "...",
                "apiVersion": "...",
                "name": "...",
                "status": "Failure",
                "details": {
                  "name: "...",
                  // ...
                }
```
</details>

~~I think the second option might be nicer, I'll follow up with that shortly for comparison.~~

~~The above appear to be existing fields in the status we could populate.~~

On closer look, name is already in use, so that won't work as first thought, nor do I think it would work with generated names well.

- (Option 3) Extend the json "key" to include additional metadata

```json
{
    "/tmp/foo.yaml:$(documentNumber}": [
```
or
```json
{
    "/tmp/foo.yaml:$(gvk}:$(name}": [
```

Potentially, we could make it so that the key is returned in the prior format if there is only 1 document in a file?

- (Option 4) Alter the return type: `map[string][]metav1.Status{}` -> `map[string][]NewType{}`

As this doesn't break the general structure of the output and simply extends it, I'm inclined to try this out:

```json
{
  "document":0, // document index
  // ... current metava1.Status fields, inline
}
```

#### Does this PR introduce a user-facing change?

```release-note
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```