### PR TITLE
fix: local CRDs for 1.34

### DIFF
--- a/pkg/openapiclient/local_crds.go
+++ b/pkg/openapiclient/local_crds.go
@@ -93,9 +93,7 @@ func (k *localCRDsClient) Paths() (map[string]openapi.GroupVersion, error) {
 		Kind:    "CustomResourceDefinition",
 	}
 	for _, document := range documents {
-		crdObj, parsedGVK, err := codecs.Decode(
-			document,
-			&crdGVK, nil)
+		crdObj, parsedGVK, err := codecs.Decode(document, &crdGVK, nil)
 
 		// If the error is that the GVK is not registered, or
 		// this objects's GK is not what we were looking for,
@@ -129,11 +127,12 @@ func (k *localCRDsClient) Paths() (map[string]openapi.GroupVersion, error) {
 				Version: v.Name,
 				Kind:    crd.Spec.Names.Kind,
 			}
-			gvkObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&gvk)
-			if err != nil {
-				return nil, err
+			gvkObj := map[string]any{
+				"group":   gvk.Group,
+				"version": gvk.Version,
+				"kind":    gvk.Kind,
 			}
-			sch.AddExtension("x-kubernetes-group-version-kind", []interface{}{gvkObj})
+			sch.AddExtension("x-kubernetes-group-version-kind", []any{gvkObj})
 			// Add schema extension to propagate the scope
 			sch.AddExtension("x-kubectl-validate-scope", string(crd.Spec.Scope))
 			key := fmt.Sprintf("%s/%s.%s", gvk.Group, gvk.Version, gvk.Kind)


### PR DESCRIPTION
Fix local CRDs for 1.34.

#### What type of PR is this?

#### What this PR does / why we need it:

Fixes changes introduced in k/k with https://github.com/kubernetes/kubernetes/commit/09912f3521932db99fe19f993db240fd43f3240e

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```