### PR TITLE
fix: RBAC resource name validation to allow colons

### DIFF
--- a/pkg/validator/custom_strategy.go
+++ b/pkg/validator/custom_strategy.go
@@ -1,0 +1,174 @@
+package validator
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+// customValidationStrategy wraps a strategy and applies custom validation for specific resource types
+type customValidationStrategy struct {
+	base            interface{} // The actual customResourceStrategy, stored as interface{}
+	gvk             schema.GroupVersionKind
+	customValidator CustomValidator
+}
+
+// Validate overrides the standard validation to apply custom validation rules
+func (s *customValidationStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	// Call the base strategy's Validate method using type assertion
+	type validator interface {
+		Validate(context.Context, runtime.Object) field.ErrorList
+	}
+	baseValidator := s.base.(validator)
+	allErrs := baseValidator.Validate(ctx, obj)
+
+	// If there's a custom validator for this resource type, apply it
+	if s.customValidator != nil {
+		// Remove DNS subdomain validation errors for metadata.name
+		// We'll re-validate with custom rules
+		filtered := field.ErrorList{}
+		hasNameError := false
+		for _, err := range allErrs {
+			// Skip DNS subdomain errors on metadata.name
+			if err.Field == "metadata.name" && err.Type == field.ErrorTypeInvalid {
+				hasNameError = true
+				continue
+			}
+			filtered = append(filtered, err)
+		}
+		allErrs = filtered
+
+		// If there was a name error, re-validate with custom rules
+		if hasNameError {
+			u, ok := obj.(*unstructured.Unstructured)
+			if ok {
+				// Get namespace scoped status
+				type scopeChecker interface {
+					NamespaceScoped() bool
+				}
+				namespaceScoped := s.base.(scopeChecker).NamespaceScoped()
+
+				// Validate with custom name validation
+				allErrs = append(allErrs, validation.ValidateObjectMetaAccessor(u, namespaceScoped, s.customValidator.ValidateName, field.NewPath("metadata"))...)
+			}
+		}
+
+		// Apply additional resource-specific validation
+		if u, ok := obj.(*unstructured.Unstructured); ok {
+			type scopeChecker interface {
+				NamespaceScoped() bool
+			}
+			namespaceScoped := s.base.(scopeChecker).NamespaceScoped()
+			allErrs = append(allErrs, s.customValidator.ValidateResource(ctx, u, namespaceScoped)...)
+		}
+	}
+
+	return allErrs
+}
+
+// Forward all other methods to the base strategy using type assertions
+
+func (s *customValidationStrategy) NamespaceScoped() bool {
+	type scopeChecker interface {
+		NamespaceScoped() bool
+	}
+	return s.base.(scopeChecker).NamespaceScoped()
+}
+
+func (s *customValidationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	type preparer interface {
+		PrepareForCreate(context.Context, runtime.Object)
+	}
+	s.base.(preparer).PrepareForCreate(ctx, obj)
+}
+
+func (s *customValidationStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	type preparer interface {
+		PrepareForUpdate(context.Context, runtime.Object, runtime.Object)
+	}
+	s.base.(preparer).PrepareForUpdate(ctx, obj, old)
+}
+
+func (s *customValidationStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	type validator interface {
+		ValidateUpdate(context.Context, runtime.Object, runtime.Object) field.ErrorList
+	}
+	return s.base.(validator).ValidateUpdate(ctx, obj, old)
+}
+
+func (s *customValidationStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	type warner interface {
+		WarningsOnCreate(context.Context, runtime.Object) []string
+	}
+	return s.base.(warner).WarningsOnCreate(ctx, obj)
+}
+
+func (s *customValidationStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	type warner interface {
+		WarningsOnUpdate(context.Context, runtime.Object, runtime.Object) []string
+	}
+	return s.base.(warner).WarningsOnUpdate(ctx, obj, old)
+}
+
+func (s *customValidationStrategy) Canonicalize(obj runtime.Object) {
+	type canonicalizer interface {
+		Canonicalize(runtime.Object)
+	}
+	s.base.(canonicalizer).Canonicalize(obj)
+}
+
+func (s *customValidationStrategy) AllowCreateOnUpdate() bool {
+	type checker interface {
+		AllowCreateOnUpdate() bool
+	}
+	return s.base.(checker).AllowCreateOnUpdate()
+}
+
+func (s *customValidationStrategy) AllowUnconditionalUpdate() bool {
+	type checker interface {
+		AllowUnconditionalUpdate() bool
+	}
+	return s.base.(checker).AllowUnconditionalUpdate()
+}
+
+func (s *customValidationStrategy) GetResetFields() map[interface{}]interface{} {
+	type fieldGetter interface {
+		GetResetFields() map[interface{}]interface{}
+	}
+	return s.base.(fieldGetter).GetResetFields()
+}
+
+func (s *customValidationStrategy) GenerateName(base string) string {
+	type nameGenerator interface {
+		GenerateName(string) string
+	}
+	return s.base.(nameGenerator).GenerateName(base)
+}
+
+func (s *customValidationStrategy) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	type objectTyper interface {
+		ObjectKinds(runtime.Object) ([]schema.GroupVersionKind, bool, error)
+	}
+	return s.base.(objectTyper).ObjectKinds(obj)
+}
+
+func (s *customValidationStrategy) Recognizes(gvk schema.GroupVersionKind) bool {
+	type objectTyper interface {
+		Recognizes(schema.GroupVersionKind) bool
+	}
+	return s.base.(objectTyper).Recognizes(gvk)
+}
+
+// newCustomValidationStrategy wraps a strategy to apply custom validation
+func newCustomValidationStrategy(base interface{}, gvk schema.GroupVersionKind) rest.RESTCreateStrategy {
+	return &customValidationStrategy{
+		base:            base,
+		gvk:             gvk,
+		customValidator: findCustomValidator(gvk),
+	}
+}

--- a/pkg/validator/custom_validators.go
+++ b/pkg/validator/custom_validators.go
@@ -1,0 +1,62 @@
+package validator
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/validation/path"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// CustomValidator defines custom validation logic for specific resource types
+type CustomValidator interface {
+	// Matches returns true if this validator should be used for the given GVK
+	Matches(gvk schema.GroupVersionKind) bool
+
+	// ValidateName validates the resource name according to resource-specific rules
+	// Returns nil if standard DNS subdomain validation should be used
+	ValidateName(name string, prefix bool) []string
+
+	// ValidateResource performs additional resource-specific validation
+	// This is called after name validation and can add more field validations
+	ValidateResource(ctx context.Context, obj *unstructured.Unstructured, namespaceScoped bool) field.ErrorList
+}
+
+// rbacValidator implements custom validation for RBAC resources
+type rbacValidator struct{}
+
+func (v *rbacValidator) Matches(gvk schema.GroupVersionKind) bool {
+	return gvk.Group == "rbac.authorization.k8s.io" &&
+		(gvk.Kind == "ClusterRole" ||
+			gvk.Kind == "Role" ||
+			gvk.Kind == "ClusterRoleBinding" ||
+			gvk.Kind == "RoleBinding")
+}
+
+func (v *rbacValidator) ValidateName(name string, prefix bool) []string {
+	// RBAC resources use path segment validation (allows colons)
+	return path.ValidatePathSegmentName(name, prefix)
+}
+
+func (v *rbacValidator) ValidateResource(ctx context.Context, obj *unstructured.Unstructured, namespaceScoped bool) field.ErrorList {
+	// Could add additional RBAC-specific validation here
+	// For example: validate PolicyRules, subjects, roleRef, etc.
+	return nil
+}
+
+// customValidatorRegistry holds all registered custom validators
+var customValidatorRegistry = []CustomValidator{
+	&rbacValidator{},
+	// Add more validators here as needed:
+}
+
+// findCustomValidator returns the custom validator for a GVK, or nil if none exists
+func findCustomValidator(gvk schema.GroupVersionKind) CustomValidator {
+	for _, validator := range customValidatorRegistry {
+		if validator.Matches(gvk) {
+			return validator
+		}
+	}
+	return nil
+}

--- a/pkg/validator/custom_validators_test.go
+++ b/pkg/validator/custom_validators_test.go
@@ -1,0 +1,251 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRBACValidator_Matches(t *testing.T) {
+	validator := &rbacValidator{}
+
+	tests := []struct {
+		name    string
+		gvk     schema.GroupVersionKind
+		matches bool
+	}{
+		{
+			name: "ClusterRole matches",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "ClusterRole",
+			},
+			matches: true,
+		},
+		{
+			name: "Role matches",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "Role",
+			},
+			matches: true,
+		},
+		{
+			name: "ClusterRoleBinding matches",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "ClusterRoleBinding",
+			},
+			matches: true,
+		},
+		{
+			name: "RoleBinding matches",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "RoleBinding",
+			},
+			matches: true,
+		},
+		{
+			name: "Pod does not match",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			matches: false,
+		},
+		{
+			name: "Deployment does not match",
+			gvk: schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			matches: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.Matches(tt.gvk)
+			assert.Equal(t, tt.matches, result)
+		})
+	}
+}
+
+func TestRBACValidator_ValidateName(t *testing.T) {
+	validator := &rbacValidator{}
+
+	tests := []struct {
+		name      string
+		inputName string
+		prefix    bool
+		wantErrs  bool
+	}{
+		{
+			name:      "name with colon is valid",
+			inputName: "system:admin",
+			prefix:    false,
+			wantErrs:  false,
+		},
+		{
+			name:      "name with multiple colons is valid",
+			inputName: "role:subrole:subsubrole",
+			prefix:    false,
+			wantErrs:  false,
+		},
+		{
+			name:      "name with slash is invalid",
+			inputName: "system/admin",
+			prefix:    false,
+			wantErrs:  true,
+		},
+		{
+			name:      "name with percent is invalid",
+			inputName: "system%admin",
+			prefix:    false,
+			wantErrs:  true,
+		},
+		{
+			name:      "name with dots is valid",
+			inputName: "system.admin.reader",
+			prefix:    false,
+			wantErrs:  false,
+		},
+		{
+			name:      "normal DNS name is valid",
+			inputName: "my-cluster-role",
+			prefix:    false,
+			wantErrs:  false,
+		},
+		{
+			name:      "dot as name is invalid",
+			inputName: ".",
+			prefix:    false,
+			wantErrs:  true,
+		},
+		{
+			name:      "double dot as name is invalid",
+			inputName: "..",
+			prefix:    false,
+			wantErrs:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.ValidateName(tt.inputName, tt.prefix)
+			if tt.wantErrs {
+				assert.NotEmpty(t, errs, "expected validation errors but got none")
+			} else {
+				assert.Empty(t, errs, "expected no validation errors but got: %v", errs)
+			}
+		})
+	}
+}
+
+func TestRBACValidator_ValidateResource(t *testing.T) {
+	validator := &rbacValidator{}
+
+	tests := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		wantErrs bool
+	}{
+		{
+			name: "valid ClusterRole",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "rbac.authorization.k8s.io/v1",
+					"kind":       "ClusterRole",
+					"metadata": map[string]interface{}{
+						"name": "test-role",
+					},
+					"rules": []interface{}{
+						map[string]interface{}{
+							"apiGroups": []interface{}{""},
+							"resources": []interface{}{"pods"},
+							"verbs":     []interface{}{"get", "list"},
+						},
+					},
+				},
+			},
+			wantErrs: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.ValidateResource(context.Background(), tt.obj, false)
+			if tt.wantErrs {
+				assert.NotEmpty(t, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestFindCustomValidator(t *testing.T) {
+	tests := []struct {
+		name      string
+		gvk       schema.GroupVersionKind
+		wantFound bool
+	}{
+		{
+			name: "finds RBAC validator for ClusterRole",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "ClusterRole",
+			},
+			wantFound: true,
+		},
+		{
+			name: "finds RBAC validator for Role",
+			gvk: schema.GroupVersionKind{
+				Group:   "rbac.authorization.k8s.io",
+				Version: "v1",
+				Kind:    "Role",
+			},
+			wantFound: true,
+		},
+		{
+			name: "returns nil for Pod",
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			wantFound: false,
+		},
+		{
+			name: "returns nil for Deployment",
+			gvk: schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findCustomValidator(tt.gvk)
+			if tt.wantFound {
+				assert.NotNil(t, result, "expected to find a custom validator")
+			} else {
+				assert.Nil(t, result, "expected no custom validator")
+			}
+		})
+	}
+}

--- a/pkg/validator/rbac_validation_test.go
+++ b/pkg/validator/rbac_validation_test.go
@@ -1,0 +1,143 @@
+package validator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kubectl-validate/pkg/openapiclient"
+)
+
+func TestRBACValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "ClusterRole with colon in name should be valid",
+			file:      "./testdata/rbac-clusterrole-with-colon.yaml",
+			wantError: false,
+		},
+		{
+			name:      "ClusterRole with normal name should be valid",
+			file:      "./testdata/rbac-clusterrole-normal.yaml",
+			wantError: false,
+		},
+		{
+			name:      "RoleBinding with colon in name should be valid",
+			file:      "./testdata/rbac-rolebinding-with-colon.yaml",
+			wantError: false,
+		},
+		{
+			name:      "ClusterRole with slash in name should be invalid",
+			file:      "./testdata/rbac-clusterrole-with-slash.yaml",
+			wantError: true,
+			errorMsg:  "may not contain '/'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create validator with hardcoded builtins
+			client := openapiclient.NewHardcodedBuiltins("1.35")
+			v, err := New(client)
+			assert.NoError(t, err)
+			assert.NotNil(t, v)
+
+			// Read test file
+			document, err := os.ReadFile(tt.file)
+			assert.NoError(t, err)
+
+			// Parse the document
+			gvk, obj, err := v.Parse(document)
+			assert.NoError(t, err)
+			assert.NotNil(t, obj)
+			assert.False(t, gvk.Empty())
+
+			// Validate
+			err = v.Validate(obj)
+
+			if tt.wantError {
+				assert.Error(t, err, "expected validation error but got none")
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err, "expected no validation error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRBACNameValidation_SystemNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		yamlName  string
+		wantError bool
+	}{
+		{
+			name:      "system:admin",
+			yamlName:  "system:admin",
+			wantError: false,
+		},
+		{
+			name:      "system:kube-controller-manager",
+			yamlName:  "system:kube-controller-manager",
+			wantError: false,
+		},
+		{
+			name:      "system:node",
+			yamlName:  "system:node",
+			wantError: false,
+		},
+		{
+			name:      "cluster-admin",
+			yamlName:  "cluster-admin",
+			wantError: false,
+		},
+		{
+			name:      "custom:with:multiple:colons",
+			yamlName:  "custom:with:multiple:colons",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create validator
+			client := openapiclient.NewHardcodedBuiltins("1.35")
+			v, err := New(client)
+			assert.NoError(t, err)
+
+			// Create a ClusterRole with the test name
+			yaml := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ` + tt.yamlName + `
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+`
+
+			// Parse and validate
+			gvk, obj, err := v.Parse([]byte(yaml))
+			assert.NoError(t, err)
+			assert.NotNil(t, obj)
+			assert.False(t, gvk.Empty())
+
+			err = v.Validate(obj)
+
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err, "expected no error for RBAC name: %s", tt.yamlName)
+			}
+		})
+	}
+}

--- a/pkg/validator/testdata/rbac-clusterrole-normal.yaml
+++ b/pkg/validator/testdata/rbac-clusterrole-normal.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: normal-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list

--- a/pkg/validator/testdata/rbac-clusterrole-with-colon.yaml
+++ b/pkg/validator/testdata/rbac-clusterrole-with-colon.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role:subrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/validator/testdata/rbac-clusterrole-with-slash.yaml
+++ b/pkg/validator/testdata/rbac-clusterrole-with-slash.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: invalid/name/with/slashes
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get

--- a/pkg/validator/testdata/rbac-rolebinding-with-colon.yaml
+++ b/pkg/validator/testdata/rbac-rolebinding-with-colon.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:admin:binding
+  namespace: default
+subjects:
+  - kind: User
+    name: admin@example.com
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -118,9 +118,12 @@ func (s *Validator) Validate(obj *unstructured.Unstructured) error {
 		return err
 	}
 
-	strat := customresource.NewStrategy(validators.ObjectTyper(gvk), isNamespaced, gvk, validators.SchemaValidator(), nil,
+	baseStrat := customresource.NewStrategy(validators.ObjectTyper(gvk), isNamespaced, gvk, validators.SchemaValidator(), nil,
 		ss,
 		nil, nil, nil)
+
+	// Wrap the strategy with custom validation (RBAC, Pod, etc.)
+	strat := newCustomValidationStrategy(baseStrat, gvk)
 
 	rest.FillObjectMetaSystemFields(obj)
 	return rest.BeforeCreate(strat, request.WithNamespace(context.TODO(), obj.GetNamespace()), obj)

--- a/testcases/manifests/error_rbac_clusterrole_invalid_name.yaml
+++ b/testcases/manifests/error_rbac_clusterrole_invalid_name.yaml
@@ -1,0 +1,33 @@
+# {
+#   "metadata": {},
+#   "status": "Failure",
+#   "message": "ClusterRole.rbac.authorization.k8s.io \"invalid/name\" is invalid: metadata.name: Invalid value: \"invalid/name\": may not contain '/'",
+#   "reason": "Invalid",
+#   "details": {
+#     "name": "invalid/name",
+#     "group": "rbac.authorization.k8s.io",
+#     "kind": "ClusterRole",
+#     "causes": [
+#       {
+#         "reason": "FieldValueInvalid",
+#         "message": "Invalid value: \"invalid/name\": may not contain '/'",
+#         "field": "metadata.name"
+#       }
+#     ]
+#   },
+#   "code": 422
+# }
+
+# Tests that RBAC ClusterRole names cannot contain slashes
+# Slashes would break path-based resource addressing
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: invalid/name
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get

--- a/testcases/manifests/rbac_clusterrole_with_colon.yaml
+++ b/testcases/manifests/rbac_clusterrole_with_colon.yaml
@@ -1,0 +1,20 @@
+# {
+#     "status": "Success",
+#     "message": ""
+# }
+
+# Tests that RBAC ClusterRole names can contain colons
+# This is valid in Kubernetes (e.g., system:admin, system:kube-controller-manager)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-insights-targetallocator:target-discovery
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Dear maintainers,

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes incorrect validation of RBAC resource names (ClusterRole, Role, ClusterRoleBinding, RoleBinding) that were being rejected when they contained colons (`:`).

**Problem:**
  kubectl-validate was incorrectly applying DNS subdomain validation (RFC 1123) to RBAC resource names, which rejected valid Kubernetes RBAC names like `system:admin`, `system:kube-controller-manager`, and `cluster-insights:targetallocator:discovery`. These names are valid in Kubernetes and commonly used  
  in built-in RBAC resources.

**Solution:**                                                                                                                                                                                                                                                                                                    
- Implemented a custom validator architecture that allows resource-specific validation rules                                                                                                                                                                                                                     
- RBAC resources now use path segment validation (matching upstream Kubernetes behavior) which allows colons, dots, and hyphens, but disallows slashes and percent signs                                                                                                                                         
- The architecture is extensible and makes it easy to add custom validators for other resource types (Pod, Service, etc.) in the future 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115

#### Special notes for your reviewer:

1. **Architecture**: The solution uses a plugin-style validator registry rather than hard-coding RBAC-specific logic, making it easy to add validators for other resource types
2. **Upstream Alignment**: The RBAC validation matches exactly what upstream Kubernetes does (uses `path.ValidatePathSegmentName` https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/rbac/validation/validation.go#L32)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed validation of RBAC resource names to allow colons. Names like `system:admin` and `cluster-role:scope:discovery` are now correctly validated as valid RBAC names.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```